### PR TITLE
Handle unicode by encoding to ascii

### DIFF
--- a/lib/rails-latex/latex_to_pdf.rb
+++ b/lib/rails-latex/latex_to_pdf.rb
@@ -90,7 +90,7 @@ class LatexToPdf
               else
                 UNICODE[m]
               end
-            }
+            }.encode('ASCII', undef: :replace) # unmapped 'unicode' chars => ?
           end
         end
       end


### PR DESCRIPTION
Replace all unmapped characters outside the ASCII range with '?'. They otherwise cause PDF generation to fail, at least with my setup.
